### PR TITLE
feat: add a way to filter list of IPs for the machine

### DIFF
--- a/net.go
+++ b/net.go
@@ -41,6 +41,35 @@ func IPAddrs() (ips []net.IP, err error) {
 	return ips, nil
 }
 
+// IPFilterFunc filters IP addresses.
+//
+// List of IPFilterFuncs is applied with AND logic: all filters should return true
+// for the IP address to be included in the response.
+type IPFilterFunc func(ip net.IP) bool
+
+// IPFilter filters list of IP addresses by applying sequence of filters.
+//
+// If any of the filters returns false, address is skipped.
+func IPFilter(addrs []net.IP, filters ...IPFilterFunc) (result []net.IP) {
+	for _, addr := range addrs {
+		skip := false
+
+		for _, filter := range filters {
+			if !filter(addr) {
+				skip = true
+
+				break
+			}
+		}
+
+		if !skip {
+			result = append(result, addr)
+		}
+	}
+
+	return result
+}
+
 // FormatAddress checks that the address has a consistent format.
 func FormatAddress(addr string) string {
 	addr = strings.Trim(addr, "[]")


### PR DESCRIPTION
This will be used to filter out SideroLink IPs on Talos side.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>