### PR TITLE
feat: switch to use `netip.Addr` instead of `net.IP`

### DIFF
--- a/net.go
+++ b/net.go
@@ -9,8 +9,8 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 )
@@ -19,63 +19,13 @@ const minPortRange = 1
 
 const maxPortRange = 65535
 
-// IPAddrs finds and returns a list of non-loopback IP addresses of the
-// current machine.
-func IPAddrs() (ips []net.IP, err error) {
-	ips = []net.IP{}
-
-	addrs, err := net.InterfaceAddrs()
-	if err != nil {
-		return
-	}
-
-	for _, a := range addrs {
-		if ipnet, ok := a.(*net.IPNet); ok {
-			if ipnet.IP.IsGlobalUnicast() && !ipnet.IP.IsLinkLocalUnicast() {
-				ips = append(ips, ipnet.IP)
-			}
-		}
-	}
-
-	return ips, nil
-}
-
-// IPFilterFunc filters IP addresses.
-//
-// List of IPFilterFuncs is applied with AND logic: all filters should return true
-// for the IP address to be included in the response.
-type IPFilterFunc func(ip net.IP) bool
-
-// IPFilter filters list of IP addresses by applying sequence of filters.
-//
-// If any of the filters returns false, address is skipped.
-func IPFilter(addrs []net.IP, filters ...IPFilterFunc) (result []net.IP) {
-	for _, addr := range addrs {
-		skip := false
-
-		for _, filter := range filters {
-			if !filter(addr) {
-				skip = true
-
-				break
-			}
-		}
-
-		if !skip {
-			result = append(result, addr)
-		}
-	}
-
-	return result
-}
-
 // FormatAddress checks that the address has a consistent format.
 func FormatAddress(addr string) string {
 	addr = strings.Trim(addr, "[]")
 
-	if ip := net.ParseIP(addr); ip != nil {
+	if ip, err := netip.ParseAddr(addr); err == nil {
 		// If this is an IPv6 address, encapsulate it in brackets
-		if ip.To4() == nil {
+		if ip.Is6() {
 			return "[" + ip.String() + "]"
 		}
 
@@ -86,72 +36,51 @@ func FormatAddress(addr string) string {
 }
 
 // FormatCIDR formats IP from the network as CIDR notation.
-func FormatCIDR(ip net.IP, network net.IPNet) string {
-	ones, _ := network.Mask.Size()
-
-	return fmt.Sprintf("%s/%d", ip, ones)
+func FormatCIDR(ip netip.Addr, network netip.Prefix) string {
+	return netip.PrefixFrom(ip, network.Bits()).String()
 }
 
 // AddressContainsPort checks to see if the supplied address contains both an address and a port.
 // This will not catch every possible permutation, but it is a best-effort routine suitable for prechecking human-interactive parameters.
 func AddressContainsPort(addr string) bool {
-	if !strings.Contains(addr, ":") || strings.Contains(addr, "/") {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
 		return false
 	}
 
-	if ip := net.ParseIP(strings.Trim(addr, "[]")); ip != nil {
-		return false
+	if strings.Contains(host, ":") {
+		if _, err := netip.ParseAddr(host); err != nil {
+			return false
+		}
 	}
 
-	pieces := strings.Split(addr, ":")
-
-	// Check to see if it parses as an IP _without_ the last (presumed) `:port`
-	trimmedAddr := strings.TrimSuffix(addr, ":"+pieces[len(pieces)-1])
-
-	if ip := net.ParseIP(strings.Trim(trimmedAddr, "[]")); ip != nil {
-		// We appear to have a valid IP followed by `:port`
-		return true
-	}
-
-	if len(pieces) > 2 {
-		// No idea what this is, but it doesn't appear to be addr:port
-		return false
-	}
-
-	// Looks like it is host:port
 	return true
 }
 
 // NthIPInNetwork takes an IPNet and returns the nth IP in it.
-func NthIPInNetwork(network *net.IPNet, n int) (net.IP, error) {
-	ip := network.IP
-	dst := make([]byte, len(ip))
-	copy(dst, ip)
+func NthIPInNetwork(network netip.Prefix, n int) (netip.Addr, error) {
+	addr := network.Addr()
 
 	for i := 0; i < n; i++ {
-		for j := len(dst) - 1; j >= 0; j-- {
-			dst[j]++
-
-			if dst[j] > 0 {
-				break
-			}
-		}
+		addr = addr.Next()
 	}
 
-	if network.Contains(dst) {
-		return dst, nil
+	if network.Contains(addr) {
+		return addr, nil
 	}
 
-	return nil, errors.New("network does not contain enough IPs")
+	return netip.Addr{}, errors.New("network does not contain enough IPs")
 }
 
 // SplitCIDRs parses list of CIDRs in a string separated by commas.
-func SplitCIDRs(cidrList string) (out []*net.IPNet, err error) {
+func SplitCIDRs(cidrList string) (out []netip.Prefix, err error) {
 	for _, podCIDR := range strings.Split(cidrList, ",") {
-		_, cidr, err := net.ParseCIDR(podCIDR)
+		cidr, err := netip.ParsePrefix(podCIDR)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse %q as a CIDR: %w", podCIDR, err)
 		}
+
+		cidr = cidr.Masked()
 
 		out = append(out, cidr)
 	}
@@ -160,7 +89,7 @@ func SplitCIDRs(cidrList string) (out []*net.IPNet, err error) {
 }
 
 // NthIPInCIDRSet returns nth IP for each CIDR in the list.
-func NthIPInCIDRSet(cidrList []*net.IPNet, offset int) (out []net.IP, err error) {
+func NthIPInCIDRSet(cidrList []netip.Prefix, offset int) (out []netip.Addr, err error) {
 	for _, cidr := range cidrList {
 		ip, err := NthIPInNetwork(cidr, offset)
 		if err != nil {
@@ -171,85 +100,6 @@ func NthIPInCIDRSet(cidrList []*net.IPNet, offset int) (out []net.IP, err error)
 	}
 
 	return out, nil
-}
-
-// DNSNames returns a default set of machine names. It includes the hostname,
-// and FQDN if the kernel domain name is set. If the kernel domain name is not
-// set, only the hostname is included in the set.
-func DNSNames() (dnsNames []string, err error) {
-	var (
-		hostname   string
-		domainname string
-	)
-
-	// Add the hostname.
-
-	if hostname, err = os.Hostname(); err != nil {
-		return nil, err
-	}
-
-	dnsNames = []string{hostname}
-
-	// Add the domain name if it is set.
-
-	if domainname, err = DomainName(); err != nil {
-		return nil, err
-	}
-
-	if domainname != "" {
-		dnsNames = append(dnsNames, fmt.Sprintf("%s.%s", hostname, domainname))
-	}
-
-	return dnsNames, nil
-}
-
-// DomainName returns the kernel domain name. If a domain name is not found, an
-// empty string is returned.
-func DomainName() (domainname string, err error) {
-	var b []byte
-
-	if b, err = os.ReadFile("/proc/sys/kernel/domainname"); err != nil {
-		return "", err
-	}
-
-	domainname = string(b)
-
-	if domainname == "(none)\n" {
-		return "", nil
-	}
-
-	return strings.TrimSuffix(domainname, "\n"), nil
-}
-
-// IsIPv6 indicates whether any IP address within the provided set is an IPv6
-// address.
-func IsIPv6(addrs ...net.IP) bool {
-	for _, a := range addrs {
-		if a == nil || a.IsLoopback() || a.IsUnspecified() {
-			continue
-		}
-
-		if a.To4() == nil {
-			if a.To16() != nil {
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
-// IsNonLocalIPv6 indicates whether provided address is non-local IPv6 address.
-func IsNonLocalIPv6(in net.IP) bool {
-	if in == nil || in.IsLoopback() || in.IsUnspecified() {
-		return false
-	}
-
-	if in.To4() == nil && in.To16() != nil {
-		return true
-	}
-
-	return false
 }
 
 // ValidateEndpointURI checks that an endpoint is valid.
@@ -292,47 +142,22 @@ func validatePortNumber(p string) error {
 	return nil
 }
 
-// ParseCIDR parses a CIDR-formatted IP address.
-// Unlike the standard library version, this will return the IP address itself, rather than the bare IP and the network address.
-// If no CIDR notation is supplied, the address is presumed to be on a solo network (/32 for IPv4 or /128 for IPv6).
-// NOTE: Unlike rtnl.ParseCIDR, this allows network addresses, since in many
-// places in the kubernetes ecosystem, the functionality of a "network address"
-// is not used and improperly prevents the use of an entire range of IP
-// addresses.
-func ParseCIDR(in string) (*net.IPNet, error) {
-	if AddressContainsPort(in) {
-		return nil, fmt.Errorf("CIDR address %q must not contain a port", in)
-	}
-
-	// Strip any IPv6 brackets.
-	in = strings.Map(func(r rune) rune {
-		switch r {
-		case '[':
-			return rune(-1)
-		case ']':
-			return rune(-1)
-		default:
-			return r
-		}
-	}, in)
-
-	// If we have no subnet, assume it is solo.
-	if soloIP := net.ParseIP(in); soloIP != nil {
-		if IsIPv6(soloIP) {
-			in += "/128"
-		} else {
-			in += "/32"
-		}
-	}
-
-	baseIP, cidr, err := net.ParseCIDR(in)
+// ParseSubnetOrAddress parses a CIDR or an IP address, returning a netip.Prefix.
+//
+// If a bare IP address is passed, it's treated as a CIDR with either /32 or /128 prefix.
+func ParseSubnetOrAddress(subnet string) (netip.Prefix, error) {
+	network, err := netip.ParsePrefix(subnet)
 	if err != nil {
-		return nil, err
+		// attempt to parse as a bare IP
+		ip, ipErr := netip.ParseAddr(subnet)
+		if ipErr == nil {
+			network = netip.PrefixFrom(ip, ip.BitLen())
+		} else {
+			return netip.Prefix{}, fmt.Errorf("failed to parse subnet: %w", err)
+		}
 	}
 
-	cidr.IP = baseIP
-
-	return cidr, nil
+	return network, nil
 }
 
 // FilterIPs filters list of IPs with the list of subnets.
@@ -340,8 +165,8 @@ func ParseCIDR(in string) (*net.IPNet, error) {
 // Each subnet can be either regular match or negative match (if prefixed with '!').
 //
 //nolint:gocognit
-func FilterIPs(ips []net.IP, cidrs []string) ([]net.IP, error) {
-	var result []net.IP
+func FilterIPs(ips []netip.Addr, cidrs []string) ([]netip.Addr, error) {
+	var result []netip.Addr
 
 	for _, subnet := range cidrs {
 		positiveMatch := true
@@ -352,9 +177,9 @@ func FilterIPs(ips []net.IP, cidrs []string) ([]net.IP, error) {
 			positiveMatch = false
 		}
 
-		network, err := ParseCIDR(subnet)
+		network, err := ParseSubnetOrAddress(subnet)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse subnet: %w", err)
+			return nil, err
 		}
 
 		for _, ip := range ips {
@@ -364,7 +189,7 @@ func FilterIPs(ips []net.IP, cidrs []string) ([]net.IP, error) {
 				found := false
 
 				for _, addr := range result {
-					if addr.Equal(ip) {
+					if addr == ip {
 						found = true
 
 						break
@@ -377,7 +202,7 @@ func FilterIPs(ips []net.IP, cidrs []string) ([]net.IP, error) {
 			case network.Contains(ip) && !positiveMatch:
 				// remote IP from the list
 				for i, addr := range result {
-					if addr.Equal(ip) {
+					if addr == ip {
 						result = append(result[:i], result[i+1:]...)
 
 						break


### PR DESCRIPTION
Refactor the implementation to use `netip.Addr`, drop some unused or low value functions (can be repliaced with `netip` native functions).

I did my best to preserve unit-tests and keep old behavior as much as possible to avoid "surprised" when replacing the implementation.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>